### PR TITLE
0.3.0_fix-build-scripts

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Create signing key
         uses: timheuer/base64-to-file@v1.2
         with:
-          fileDir: "android/"
+          fileDir: "/home/runner/work/album_share/android/"
           fileName: "keystore.jks"
           encodedString: ${{ secrets.ANDROID_KEY_BASE64 }}
 
@@ -56,7 +56,6 @@ jobs:
 
       - name: Add files to release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -95,7 +94,6 @@ jobs:
 
       - name: Add archive to release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -129,45 +127,43 @@ jobs:
 
       - name: Add archive to release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: build/windows/x64/runner/Release/AlbumShare-{{github.ref_name}}-windows.zip
 
-  build_macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
+  # build_macos:
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Setup the flutter environment
-        uses: subosito/flutter-action@v2
-        with:
-          channel: "stable"
+  #     - name: Setup the flutter environment
+  #       uses: subosito/flutter-action@v2
+  #       with:
+  #         channel: "stable"
 
-      - name: Install project dependencies
-        run: flutter pub get
+  #     - name: Install project dependencies
+  #       run: flutter pub get
 
-      - name: Generate build files
-        run: dart run build_runner build --delete-conflicting-outputs
+  #     - name: Generate build files
+  #       run: dart run build_runner build --delete-conflicting-outputs
 
-      - name: Build
-        run: flutter build macos --release
+  #     - name: Build
+  #       run: flutter build macos --release
 
-      - name: Creative archive
-        uses: thedoctor0/zip-release@0.7.6
-        with:
-          type: "zip"
-          filename: AlbumShare-{{github.ref_name}}-macos.zip
-          directory: build/macos/Build/Products/Release
+  #     - name: Creative archive
+  #       uses: thedoctor0/zip-release@0.7.6
+  #       with:
+  #         type: "zip"
+  #         filename: AlbumShare-{{github.ref_name}}-macos.zip
+  #         directory: build/macos/Build/Products/Release
 
-      - name: Add archive to release
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: build/macos/Build/Products/Release/AlbumShare-{{github.ref_name}}-macos.zip
+  #     - name: Add archive to release
+  #       uses: softprops/action-gh-release@v2
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         files: build/macos/Build/Products/Release/AlbumShare-{{github.ref_name}}-macos.zip
 
   # build_ios:
   #   runs-on: macos-latest

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   VideoPlayer.ensureInitialized();
   AppWindow.ensureInitialized();
-
   runApp(
     const ProviderScope(
       child: LocaleScope(


### PR DESCRIPTION
fixes Android build failing due to keystore.jks (hopefully)

disables macOS build.
More work required before macOS and iOS builds can be enabled.

Adds whitespace to trigger build and release of v0.3.0
