### PR TITLE
fix: server-info deprecated use server instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ app.*.map.json
 .cookies
 # Signing key
 upload-key.jks
+api.http

--- a/lib/services/api/api_service.dart
+++ b/lib/services/api/api_service.dart
@@ -89,7 +89,7 @@ class ApiService {
 
     try {
       final body = await _get(
-        '/api/server-info/features',
+        '/api/server/features',
         expected: JSON_MAP,
       );
 
@@ -109,7 +109,7 @@ class ApiService {
   Future<bool> _isEndpointAvailable(String serverUrl) async {
     try {
       await _dio.get(
-        '$serverUrl/api/server-info/ping',
+        '$serverUrl/api/server/ping',
         options: Options(
           headers: {'Accepts': _applicationJson},
           sendTimeout: const Duration(seconds: 5),


### PR DESCRIPTION
Removes the deprecated endpoint `/api/server-info`.

I missed the deprecation of this endpoint in Immich so this endpoint has been completely removed from the API.
See: https://github.com/immich-app/immich/releases/tag/v1.118.0