### PR TITLE
Fix_password_resets

### DIFF
--- a/lib/screens/auth/change_password_widget.dart
+++ b/lib/screens/auth/change_password_widget.dart
@@ -1,10 +1,10 @@
-import 'package:album_share/routes/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/components/app_snackbar.dart';
 import '../../core/utils/app_localisations.dart';
 import '../../core/utils/validators.dart';
+import '../../routes/app_router.dart';
 import '../../services/api/api_service.dart';
 import '../../services/auth/auth_providers.dart';
 
@@ -76,7 +76,7 @@ class _LoginWidgetState extends ConsumerState<ChangePasswordWidget> {
 
     await ref
         .read(AuthProviders.service)
-        .changePassword(_newPassword)
+        .changePassword(_password, _newPassword)
         .then((_) => widget.onComplete())
         .onError((ApiException e, _) => _onError(e.message));
   }

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -132,11 +132,16 @@ class AuthService {
     return user;
   }
 
-  Future<void> changePassword(String password) async {
-    final user = await _api.changePassword(password);
+  Future<bool> changePassword(String password, String newPassword) async {
+    final passwordChanged = await _api.changePassword(password, newPassword);
 
-    await _db.setUser(user);
-    _currentUserStream.add(user);
+    if (passwordChanged) {
+      final user = await _api.updateUser(password: newPassword);
+      await _db.setUser(user);
+      _currentUserStream.add(user);
+    }
+
+    return passwordChanged;
   }
 
   /// A stream of events for the current user.


### PR DESCRIPTION
The 'change-password' endpoint does not update 'shouldChagePassword' however the 'updateMyUser' endpoint does not validate the current password.

This update uses both endpoints to ensure the exisiting password is validated, new password is changed and the user is updated.