### PR TITLE
fix: builds fail due to outdated versions

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: "17"
+          java-version: "21"
 
       - name: Setup the flutter environment
         uses: subosito/flutter-action@v2

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.0.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'core/main/main_app.dart';
 import 'core/theme/app_theme.dart';
 
 void main() {
+  //
   WidgetsFlutterBinding.ensureInitialized();
   AppTheme.ensureInitialized();
   VideoPlayer.ensureInitialized();


### PR DESCRIPTION
This pull request updates the Android build environment to use newer versions of Java, Gradle, and key plugins. 

**Build environment updates:**

* [`.github/workflows/build_release.yaml`](diffhunk://#diff-e28ac92fe298dd88729d54de8de34cd7267860b04200e25ddabc36062c452c55L53-R53): Updated the Java version used in the CI workflow from 17 to 21.
* [`android/gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-4c5ffadbdf6016477a1c3768e0b7381cc298bd558b1784871f407cbcb0efacceL5-R5): Upgraded the Gradle wrapper from version 8.14 to 9.1.0.

**Plugin version upgrades:**

* [`android/settings.gradle.kts`](diffhunk://#diff-b846529d3b9af5e34dfb0174742f9dc3d52bcd97761555bc61271a7a868870b9L22-R23): Bumped `com.android.application` plugin from 8.11.1 to 9.0.2 and `org.jetbrains.kotlin.android` plugin from 2.2.20 to 2.3.20.